### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server that enables AI agents to perform sophisticated knowledge discovery and analysis across your Obsidian vault through the Local REST API plugin.
 
+<a href="https://glama.ai/mcp/servers/@pmmvr/obsidian-api-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pmmvr/obsidian-api-mcp-server/badge" alt="Obsidian Server MCP server" />
+</a>
+
 ## Why This Matters
 
 This server transforms your Obsidian vault into a powerful knowledge base for AI agents, enabling complex multi-step workflows like:


### PR DESCRIPTION
This PR adds a badge for the [Obsidian MCP Server](https://glama.ai/mcp/servers/@pmmvr/obsidian-api-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@pmmvr/obsidian-api-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pmmvr/obsidian-api-mcp-server/badge" alt="Obsidian Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.